### PR TITLE
pygments rename highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ markdown: kramdown
 paginate: 5
 excerpt_separator: <!--more-->
 exclude: [Gruntfile.js, package.json, wordpress.xml, less, scss]
-pygments: true
+highlighter: true
 
 # Mapbox settings
 mapbox_token: pk.eyJ1IjoiYWxpZW5sZWJhcmdlIiwiYSI6Ik1hN3ZxVjgifQ.S2hbxqNnn7kU7HRnd6jYVg


### PR DESCRIPTION
Get the following alert when running Jekyll

```
Deprecation: The 'pygments' configuration option has been renamed to 'highlighter'. Please update your config file accordingly. The allowed values are 'rouge', 'pygments' or null.
```
